### PR TITLE
Update Cilium version to v1.16.6 and CNI plugins image to v1.6.2-build20250124

### DIFF
--- a/packages/rke2-cilium/generated-changes/patch/Chart.yaml.patch
+++ b/packages/rke2-cilium/generated-changes/patch/Chart.yaml.patch
@@ -2,7 +2,7 @@
 +++ charts/Chart.yaml
 @@ -81,8 +81,7 @@
  apiVersion: v2
- appVersion: 1.16.5
+ appVersion: 1.16.6
  description: eBPF-based Networking, Security, and Observability
 -home: https://cilium.io/
 -icon: https://cdn.jsdelivr.net/gh/cilium/cilium@main/Documentation/images/logo-solo.svg
@@ -19,4 +19,4 @@
  sources:
 -- https://github.com/cilium/cilium
 +- https://github.com/rancher/rke2-charts
- version: 1.16.5
+ version: 1.16.6

--- a/packages/rke2-cilium/generated-changes/patch/templates/cilium-agent/daemonset.yaml.patch
+++ b/packages/rke2-cilium/generated-changes/patch/templates/cilium-agent/daemonset.yaml.patch
@@ -41,7 +41,7 @@
          imagePullPolicy: {{ .Values.image.pullPolicy }}
          {{- if .Values.sleepAfterInit }}
          command:
-@@ -397,7 +405,7 @@
+@@ -393,7 +401,7 @@
          {{- end }}
        {{- if .Values.monitor.enabled }}
        - name: cilium-monitor
@@ -50,7 +50,7 @@
          imagePullPolicy: {{ .Values.image.pullPolicy }}
          command:
          - /bin/bash
-@@ -428,8 +436,18 @@
+@@ -424,8 +432,18 @@
        {{- toYaml .Values.extraContainers | nindent 6 }}
        {{- end }}
        initContainers:
@@ -70,7 +70,7 @@
          imagePullPolicy: {{ .Values.image.pullPolicy }}
          command:
          - cilium-dbg
-@@ -482,7 +500,7 @@
+@@ -478,7 +496,7 @@
        # Required to mount cgroup2 filesystem on the underlying Kubernetes node.
        # We use nsenter command with host's cgroup and mount namespaces enabled.
        - name: mount-cgroup
@@ -79,7 +79,7 @@
          imagePullPolicy: {{ .Values.image.pullPolicy }}
          env:
          - name: CGROUP_ROOT
-@@ -530,7 +548,7 @@
+@@ -526,7 +544,7 @@
        {{- end }}
        {{- if .Values.sysctlfix.enabled }}
        - name: apply-sysctl-overwrites
@@ -88,7 +88,7 @@
          imagePullPolicy: {{ .Values.image.pullPolicy }}
          {{- with .Values.initResources }}
          resources:
-@@ -579,7 +597,7 @@
+@@ -575,7 +593,7 @@
        # from a privileged container because the mount propagation bidirectional
        # only works from privileged containers.
        - name: mount-bpf-fs
@@ -97,7 +97,7 @@
          imagePullPolicy: {{ .Values.image.pullPolicy }}
          {{- with .Values.initResources }}
          resources:
-@@ -603,7 +621,7 @@
+@@ -599,7 +617,7 @@
        {{- end }}
        {{- if and .Values.nodeinit.enabled .Values.nodeinit.bootstrapFile }}
        - name: wait-for-node-init
@@ -106,7 +106,7 @@
          imagePullPolicy: {{ .Values.image.pullPolicy }}
          {{- with .Values.initResources }}
          resources:
-@@ -621,9 +639,11 @@
+@@ -617,9 +635,11 @@
          volumeMounts:
          - name: cilium-bootstrap-file-dir
            mountPath: "/tmp/cilium-bootstrap.d"
@@ -119,7 +119,7 @@
          imagePullPolicy: {{ .Values.image.pullPolicy }}
          command:
          - /init-container.sh
-@@ -692,7 +712,7 @@
+@@ -688,7 +708,7 @@
          {{- end }}
        {{- if and .Values.waitForKubeProxy (and (ne (toString $kubeProxyReplacement) "strict") (ne (toString $kubeProxyReplacement) "true"))  }}
        - name: wait-for-kube-proxy
@@ -128,7 +128,7 @@
          imagePullPolicy: {{ .Values.image.pullPolicy }}
          {{- with .Values.initResources }}
          resources:
-@@ -730,7 +750,7 @@
+@@ -726,7 +746,7 @@
        {{- if .Values.cni.install }}
        # Install the CNI binaries in an InitContainer so we don't have a writable host mount in the agent
        - name: install-cni-binaries

--- a/packages/rke2-cilium/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-cilium/generated-changes/patch/values.yaml.patch
@@ -6,10 +6,10 @@
    override: ~
 -  repository: "quay.io/cilium/cilium"
 +  repository: "rancher/mirrored-cilium-cilium"
-   tag: "v1.16.5"
+   tag: "v1.16.6"
    pullPolicy: "IfNotPresent"
 -  # cilium-digest
--  digest: "sha256:758ca0793f5995bb938a2fa219dcce63dc0b3fa7fc4ce5cc851125281fb7361d"
+-  digest: "sha256:1e0896b1c4c188b4812c7e0bed7ec3f5631388ca88325c1391a0ef9172c448da"
 -  useDigest: true
 +  useDigest: false
  # -- Affinity for cilium-agent.
@@ -55,9 +55,9 @@
        override: ~
 -      repository: "quay.io/cilium/hubble-relay"
 +      repository: "rancher/mirrored-cilium-hubble-relay"
-       tag: "v1.16.5"
+       tag: "v1.16.6"
 -      # hubble-relay-digest
--      digest: "sha256:6cfae1d1afa566ba941f03d4d7e141feddd05260e5cd0a1509aba1890a45ef00"
+-      digest: "sha256:ca8dcaa5a81a37743b1397ba2221d16d5d63e4a47607584f1bf50a3b0882bf3b"
 -      useDigest: true
 +      useDigest: false
        pullPolicy: "IfNotPresent"
@@ -126,9 +126,9 @@
      override: ~
 -    repository: "quay.io/cilium/cilium-envoy"
 +    repository: "rancher/mirrored-cilium-cilium-envoy"
-     tag: "v1.30.8-1733837904-eaae5aca0fb988583e5617170a65ac5aa51c0aa8"
+     tag: "v1.30.9-1737073743-40a016d11c0d863b772961ed0168eea6fe6b10a5"
      pullPolicy: "IfNotPresent"
--    digest: "sha256:709c08ade3d17d52da4ca2af33f431360ec26268d288d9a6cd1d98acc9a1dced"
+-    digest: "sha256:a69dfe0e54b24b0ff747385c8feeae0612cfbcae97bfcc8ee42a773bb3f69c88"
 -    useDigest: true
 +    useDigest: false
    # -- Additional containers added to the cilium Envoy DaemonSet.
@@ -140,15 +140,15 @@
      override: ~
 -    repository: "quay.io/cilium/operator"
 +    repository: "rancher/mirrored-cilium-operator"
-     tag: "v1.16.5"
+     tag: "v1.16.6"
 -    # operator-generic-digest
--    genericDigest: "sha256:f7884848483bbcd7b1e0ccfd34ba4546f258b460cb4b7e2f06a1bcc96ef88039"
+-    genericDigest: "sha256:13d32071d5a52c069fb7c35959a56009c6914439adc73e99e098917646d154fc"
 -    # operator-azure-digest
--    azureDigest: "sha256:265e2b78f572c76b523f91757083ea5f0b9b73b82f2d9714e5a8fb848e4048f9"
+-    azureDigest: "sha256:0a05d7aea760923897aabd715213ab11a706051673d41fab3874a37f897c1bdd"
 -    # operator-aws-digest
--    awsDigest: "sha256:97e1fe0c2b522583033138eb10c170919d8de49d2788ceefdcff229a92210476"
+-    awsDigest: "sha256:d11ee1cfa3465defe2df7ec1c6e8a77bcaf280b44d2c61aa7496c58b29550f6d"
 -    # operator-alibabacloud-digest
--    alibabacloudDigest: "sha256:c0edf4c8d089e76d6565d3c57128b98bc6c73d14bb4590126ee746aeaedba5e0"
+-    alibabacloudDigest: "sha256:0e3c7fbcb6bde9a247cd2dd3d25230e2859d40d2eb58aba6265a2aab216775a9"
 -    useDigest: true
 +    useDigest: false
      pullPolicy: "IfNotPresent"
@@ -170,9 +170,9 @@
      override: ~
 -    repository: "quay.io/cilium/cilium"
 +    repository: "rancher/mirrored-cilium-cilium"
-     tag: "v1.16.5"
+     tag: "v1.16.6"
 -    # cilium-digest
--    digest: "sha256:758ca0793f5995bb938a2fa219dcce63dc0b3fa7fc4ce5cc851125281fb7361d"
+-    digest: "sha256:1e0896b1c4c188b4812c7e0bed7ec3f5631388ca88325c1391a0ef9172c448da"
 -    useDigest: true
 +    useDigest: false
      pullPolicy: "IfNotPresent"
@@ -184,9 +184,9 @@
        override: ~
 -      repository: "quay.io/cilium/clustermesh-apiserver"
 +      repository: "rancher/mirrored-cilium-clustermesh-apiserver"
-       tag: "v1.16.5"
+       tag: "v1.16.6"
 -      # clustermesh-apiserver-digest
--      digest: "sha256:37a7fdbef806b78ef63df9f1a9828fdddbf548d1f0e43b8eb10a6bdc8fa03958"
+-      digest: "sha256:ab2070ea48a52a55d961b81b7b5fbac7d40a3f428be9b1b6b9071d47f194456a"
 -      useDigest: true
 +      useDigest: false
        pullPolicy: "IfNotPresent"

--- a/packages/rke2-cilium/package.yaml
+++ b/packages/rke2-cilium/package.yaml
@@ -1,2 +1,2 @@
-url: https://helm.cilium.io/cilium-1.16.5.tgz
-packageVersion: 01
+url: https://helm.cilium.io/cilium-1.16.6.tgz
+packageVersion: 00


### PR DESCRIPTION



<Actions>
    <action id="9f2a1a904b57d2e000d70ce8846ca1c460e9b72a7b72f51e30bc766139ae0d19">
        <h3>Update Cilium version</h3>
        <details id="04343367bedc8bc45741f90150e743990773277508f540d889fd5d7fba9672e1">
            <summary>Bump to latest cilium version on the chart</summary>
            <p>ran shell command &#34;updatecli/scripts/update-cilium.sh v1.16.6&#34;</p>
            <details>
                <summary>v1.16.6</summary>
                <pre>&#xA;Release published on the 2025-01-22 00:54:20 +0000 UTC at the url https://github.com/cilium/cilium/releases/tag/v1.16.6&#xA;&#xA;Summary of Changes&#xD;&#xA;------------------&#xD;&#xA;&#xD;&#xA;**Major Changes:**&#xD;&#xA;* Add feature tracking in Cilium agent as prometheus metrics (Backport PR cilium/cilium#36263, Upstream PR cilium/cilium#35852, @aanm)&#xD;&#xA;* Add feature tracking in Cilium Operator as prometheus metrics (Backport PR cilium/cilium#36263, Upstream PR cilium/cilium#36077, @aanm)&#xD;&#xA;&#xD;&#xA;**Minor Changes:**&#xD;&#xA;* envoy: Use yaml format for bootstrap config (Backport PR cilium/cilium#36782, Upstream PR cilium/cilium#36820, @sayboras)&#xD;&#xA;* Reject CNP/CCNP with CIDR rules where CIDRGroupRef is used in combination with ExceptCIDRs (cilium/cilium#36561, @pippolo84)&#xD;&#xA;* service: Cap number of backends included in monitor message (Backport PR cilium/cilium#36635, Upstream PR cilium/cilium#36394, @joamaki)&#xD;&#xA;&#xD;&#xA;**Bugfixes:**&#xD;&#xA;* cilium: LB source ranges fixes (Backport PR cilium/cilium#36635, Upstream PR cilium/cilium#36517, @borkmann)&#xD;&#xA;* eni.subnetTagsFilter and eni.instanceTagsFilter are now templated to comma separated string (Backport PR cilium/cilium#36872, Upstream PR cilium/cilium#36617, @sderoe)&#xD;&#xA;* envoy: Configure internal address config based on IP family (Backport PR cilium/cilium#36782, Upstream PR cilium/cilium#36733, @sayboras)&#xD;&#xA;* Fix connectivity issue caused by stale cilium eBPF program when using --bpf-filter-priority (Backport PR cilium/cilium#36635, Upstream PR cilium/cilium#36176, @tamilmani1989)&#xD;&#xA;* metrics/features: remove reporting metrics&#39; defaults by default (Backport PR cilium/cilium#36263, Upstream PR cilium/cilium#36298, @aanm)&#xD;&#xA;* pkg/redirectpolicy: Fix backend slices in processConfig (Backport PR cilium/cilium#36872, Upstream PR cilium/cilium#35496, @Sm0ckingBird)&#xD;&#xA;* ui: drop CORS headers from api response (Backport PR cilium/cilium#36872, Upstream PR cilium/cilium#35762, @geakstr)&#xD;&#xA;&#xD;&#xA;**CI Changes:**&#xD;&#xA;* [v1.16] .github: Remove CI Fuzz workflow (cilium/cilium#36641, @joestringer)&#xD;&#xA;* [v1.16] gh: e2e-upgrade: use 6.12 kernel for netkit test configs (cilium/cilium#36620, @julianwiedmann)&#xD;&#xA;* [v1.16] gha: use /test to trigger tests in stable branches (cilium/cilium#36673, @giorio94)&#xD;&#xA;* ci: fix job names for various ci workflows (Backport PR cilium/cilium#36263, Upstream PR cilium/cilium#36397, @marseel)&#xD;&#xA;* Extend the check-ipsec-leak bpftrace script to capture additional details of leaked packets (Backport PR cilium/cilium#36872, Upstream PR cilium/cilium#33398, @giorio94)&#xD;&#xA;* gh: e2e-upgrade: add coverage for 6.6 kernel (Backport PR cilium/cilium#36988, Upstream PR cilium/cilium#36626, @julianwiedmann)&#xD;&#xA;* gh: e2e-upgrade: de-renovate the config example (Backport PR cilium/cilium#36635, Upstream PR cilium/cilium#36463, @julianwiedmann)&#xD;&#xA;* gha: drop leftover token parameter in net-perf-gke workflow (cilium/cilium#36684, @giorio94)&#xD;&#xA;* gha: fix merging of features-related artifacts (cilium/cilium#36665, @giorio94)&#xD;&#xA;* gha: merge artifacts in net-perf-gke workflow (Backport PR cilium/cilium#36263, Upstream PR cilium/cilium#36236, @giorio94)&#xD;&#xA;* gha: Use ubuntu-24.04 for integration-test (Backport PR cilium/cilium#36659, Upstream PR cilium/cilium#36628, @sayboras)&#xD;&#xA;&#xD;&#xA;**Misc Changes:**&#xD;&#xA;* .github/workflows: always install cilium-cli (Backport PR cilium/cilium#36263, Upstream PR cilium/cilium#36234, @aanm)&#xD;&#xA;* .github/workflows: do not fail ginkgo if unable to fetch features (Backport PR cilium/cilium#36263, Upstream PR cilium/cilium#36461, @aanm)&#xD;&#xA;* .github: fix conformance-k8s NP test (Backport PR cilium/cilium#36263, Upstream PR cilium/cilium#36355, @aanm)&#xD;&#xA;* [v1.16] Use bash syntax to consume env variable (cilium/cilium#36636, @ferozsalam)&#xD;&#xA;* Add more features tracking in Cilium agent as prometheus metrics (Backport PR cilium/cilium#36263, Upstream PR cilium/cilium#36078, @aanm)&#xD;&#xA;* Add policy-related features tracking in Cilium agent as prometheus metrics (Backport PR cilium/cilium#36263, Upstream PR cilium/cilium#36203, @aanm)&#xD;&#xA;* Add the tls:// prefix in the Hubble TLS doc (Backport PR cilium/cilium#36635, Upstream PR cilium/cilium#36410, @liyihuang)&#xD;&#xA;* chore(deps): update all github action dependencies (v1.16) (cilium/cilium#36612, @cilium-renovate[bot])&#xD;&#xA;* chore(deps): update all github action dependencies (v1.16) (cilium/cilium#36762, @cilium-renovate[bot])&#xD;&#xA;* chore(deps): update all github action dependencies (v1.16) (cilium/cilium#36950, @cilium-renovate[bot])&#xD;&#xA;* chore(deps): update all github action dependencies (v1.16) (cilium/cilium#37099, @cilium-renovate[bot])&#xD;&#xA;* chore(deps): update all github action dependencies (v1.16) (patch) (cilium/cilium#36760, @cilium-renovate[bot])&#xD;&#xA;* chore(deps): update all-dependencies (v1.16) (cilium/cilium#36707, @cilium-renovate[bot])&#xD;&#xA;* chore(deps): update all-dependencies (v1.16) (cilium/cilium#36787, @cilium-renovate[bot])&#xD;&#xA;* chore(deps): update all-dependencies (v1.16) (cilium/cilium#36949, @cilium-renovate[bot])&#xD;&#xA;* chore(deps): update all-dependencies (v1.16) (cilium/cilium#37033, @cilium-renovate[bot])&#xD;&#xA;* chore(deps): update dependency cilium/cilium-cli to v0.16.23 (v1.16) (cilium/cilium#36895, @cilium-renovate[bot])&#xD;&#xA;* chore(deps): update docker.io/library/busybox:1.36.1 docker digest to 7c3c3ce (v1.16) (cilium/cilium#36609, @cilium-renovate[bot])&#xD;&#xA;* chore(deps): update docker.io/library/golang:1.22.10 docker digest to 1a6e657 (v1.16) (cilium/cilium#36850, @cilium-renovate[bot])&#xD;&#xA;* chore(deps): update docker.io/library/golang:1.22.10 docker digest to 9855006 (v1.16) (cilium/cilium#36610, @cilium-renovate[bot])&#xD;&#xA;* chore(deps): update go to v1.22.11 (v1.16) (cilium/cilium#37045, @cilium-renovate[bot])&#xD;&#xA;* chore(deps): update helm/kind-action action to v1.12.0 (v1.16) (cilium/cilium#36839, @cilium-renovate[bot])&#xD;&#xA;* chore(deps): update stable lvh-images (v1.16) (patch) (cilium/cilium#36611, @cilium-renovate[bot])&#xD;&#xA;* chore(deps): update stable lvh-images (v1.16) (patch) (cilium/cilium#36699, @cilium-renovate[bot])&#xD;&#xA;* doc: fix typo on kubeproxy-free (CEV -&gt; CVE) (Backport PR cilium/cilium#36872, Upstream PR cilium/cilium#36701, @alagoutte)&#xD;&#xA;* docs: Add missing default identity label in the description of identity-relevant labels&#39; example (Backport PR cilium/cilium#36635, Upstream PR cilium/cilium#36558, @liyihuang)&#xD;&#xA;* docs: Clarify the behavior of CiliumNetworkPolicies toCIDRSet (Backport PR cilium/cilium#36635, Upstream PR cilium/cilium#36549, @verysonglaa)&#xD;&#xA;* Ensure debug symbols are generated for the debug image even when stripping symbols for the release image. (Backport PR cilium/cilium#36635, Upstream PR cilium/cilium#36417, @EricMountain)&#xD;&#xA;* Fix `make -C Documentation update-cmdref` when make uses `--jobserver-style=fifo`. (Backport PR cilium/cilium#36872, Upstream PR cilium/cilium#36788, @gentoo-root)&#xD;&#xA;* fix(deps): update module golang.org/x/net to v0.33.0 [security] (v1.16) (cilium/cilium#36711, @cilium-renovate[bot])&#xD;&#xA;* ingress, gateway-api: Convert test fixtures to file based (Backport PR cilium/cilium#36782, Upstream PR cilium/cilium#36732, @sayboras)&#xD;&#xA;* metrics/features: enable ClusterMesh (Backport PR cilium/cilium#36263, Upstream PR cilium/cilium#36402, @aanm)&#xD;&#xA;* metrics/features: refactor metric names (Backport PR cilium/cilium#36263, Upstream PR cilium/cilium#36209, @aanm)&#xD;&#xA;* Prepare for release v1.16.6 (cilium/cilium#36989, @cilium-release-bot[bot])&#xD;&#xA;* Remove reference to DNS polling (Backport PR cilium/cilium#36872, Upstream PR cilium/cilium#36679, @JacobHenner)&#xD;&#xA;&#xD;&#xA;**Other Changes:**&#xD;&#xA;* [v1.16] author backport: helm: avoid setting bpf-lb-sock-terminate-pod-connections (cilium/cilium#36650, @ysksuzuki)&#xD;&#xA;* install: Update image digests for v1.16.5 (cilium/cilium#36671, @cilium-release-bot[bot])&#xD;&#xA;&#xD;&#xA;&#xD;&#xA;## Docker Manifests&#xD;&#xA;&#xD;&#xA;### cilium&#xD;&#xA;&#xD;&#xA;`quay.io/cilium/cilium:v1.16.6@sha256:1e0896b1c4c188b4812c7e0bed7ec3f5631388ca88325c1391a0ef9172c448da`&#xD;&#xA;`quay.io/cilium/cilium:stable@sha256:1e0896b1c4c188b4812c7e0bed7ec3f5631388ca88325c1391a0ef9172c448da`&#xD;&#xA;&#xD;&#xA;### clustermesh-apiserver&#xD;&#xA;&#xD;&#xA;`quay.io/cilium/clustermesh-apiserver:v1.16.6@sha256:ab2070ea48a52a55d961b81b7b5fbac7d40a3f428be9b1b6b9071d47f194456a`&#xD;&#xA;`quay.io/cilium/clustermesh-apiserver:stable@sha256:ab2070ea48a52a55d961b81b7b5fbac7d40a3f428be9b1b6b9071d47f194456a`&#xD;&#xA;&#xD;&#xA;### docker-plugin&#xD;&#xA;&#xD;&#xA;`quay.io/cilium/docker-plugin:v1.16.6@sha256:f8f5833a60900b0264fd8982b11329e130c1a326afe2e4653e9f2d2e3fb2af66`&#xD;&#xA;`quay.io/cilium/docker-plugin:stable@sha256:f8f5833a60900b0264fd8982b11329e130c1a326afe2e4653e9f2d2e3fb2af66`&#xD;&#xA;&#xD;&#xA;### hubble-relay&#xD;&#xA;&#xD;&#xA;`quay.io/cilium/hubble-relay:v1.16.6@sha256:ca8dcaa5a81a37743b1397ba2221d16d5d63e4a47607584f1bf50a3b0882bf3b`&#xD;&#xA;`quay.io/cilium/hubble-relay:stable@sha256:ca8dcaa5a81a37743b1397ba2221d16d5d63e4a47607584f1bf50a3b0882bf3b`&#xD;&#xA;&#xD;&#xA;### operator-alibabacloud&#xD;&#xA;&#xD;&#xA;`quay.io/cilium/operator-alibabacloud:v1.16.6@sha256:0e3c7fbcb6bde9a247cd2dd3d25230e2859d40d2eb58aba6265a2aab216775a9`&#xD;&#xA;`quay.io/cilium/operator-alibabacloud:stable@sha256:0e3c7fbcb6bde9a247cd2dd3d25230e2859d40d2eb58aba6265a2aab216775a9`&#xD;&#xA;&#xD;&#xA;### operator-aws&#xD;&#xA;&#xD;&#xA;`quay.io/cilium/operator-aws:v1.16.6@sha256:d11ee1cfa3465defe2df7ec1c6e8a77bcaf280b44d2c61aa7496c58b29550f6d`&#xD;&#xA;`quay.io/cilium/operator-aws:stable@sha256:d11ee1cfa3465defe2df7ec1c6e8a77bcaf280b44d2c61aa7496c58b29550f6d`&#xD;&#xA;&#xD;&#xA;### operator-azure&#xD;&#xA;&#xD;&#xA;`quay.io/cilium/operator-azure:v1.16.6@sha256:0a05d7aea760923897aabd715213ab11a706051673d41fab3874a37f897c1bdd`&#xD;&#xA;`quay.io/cilium/operator-azure:stable@sha256:0a05d7aea760923897aabd715213ab11a706051673d41fab3874a37f897c1bdd`&#xD;&#xA;&#xD;&#xA;### operator-generic&#xD;&#xA;&#xD;&#xA;`quay.io/cilium/operator-generic:v1.16.6@sha256:13d32071d5a52c069fb7c35959a56009c6914439adc73e99e098917646d154fc`&#xD;&#xA;`quay.io/cilium/operator-generic:stable@sha256:13d32071d5a52c069fb7c35959a56009c6914439adc73e99e098917646d154fc`&#xD;&#xA;&#xD;&#xA;### operator&#xD;&#xA;&#xD;&#xA;`quay.io/cilium/operator:v1.16.6@sha256:09ab2878e103fa32a00fd1fe4469f7042cfb053627b44c82fa03a04a820c0b46`&#xD;&#xA;`quay.io/cilium/operator:stable@sha256:09ab2878e103fa32a00fd1fe4469f7042cfb053627b44c82fa03a04a820c0b46`&#xD;&#xA;&#xD;&#xA;</pre>
            </details>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

