### PR TITLE
Update Kubernetes Metrics Server chart 3.13.0

### DIFF
--- a/packages/rke2-metrics-server/generated-changes/patch/values.yaml.patch
+++ b/packages/rke2-metrics-server/generated-changes/patch/values.yaml.patch
@@ -8,7 +8,7 @@
 +  repository: rancher/hardened-k8s-metrics-server
    # Overrides the image tag whose default is v{{ .Chart.AppVersion }}
 -  tag: ""
-+  tag: v0.8.1-build20260413
++  tag: v0.8.1-build20260511
    pullPolicy: IfNotPresent
  
  imagePullSecrets: []
@@ -27,7 +27,7 @@
 -    repository: registry.k8s.io/autoscaling/addon-resizer
 -    tag: 1.8.23
 +    repository: rancher/hardened-addon-resizer
-+    tag: 1.8.23-build20260413
++    tag: 1.8.23-build20260511
    securityContext:
      allowPrivilegeEscalation: false
      readOnlyRootFilesystem: true

--- a/packages/rke2-metrics-server/package.yaml
+++ b/packages/rke2-metrics-server/package.yaml
@@ -1,2 +1,2 @@
 url: https://github.com/kubernetes-sigs/metrics-server/releases/download/metrics-server-helm-chart-3.13.0/metrics-server-3.13.0.tgz
-packageVersion: 09
+packageVersion: 10

--- a/updatecli/scripts/create-issue.sh
+++ b/updatecli/scripts/create-issue.sh
@@ -3,7 +3,7 @@
 ISSUE_BODY="Failed workflow run: ${UPDATECLI_GITHUB_WORKFLOW_URL}"
 
 GITHUB_APP="rancher-issues-manager"
-GITHUB_REPOSITORY="rancher/rke2"
+GITHUB_REPOSITORY="mgfritch/rke2"
 
 report-error() {
     exit_code=$?

--- a/updatecli/scripts/update-calico.sh
+++ b/updatecli/scripts/update-calico.sh
@@ -7,27 +7,33 @@ ISSUE_TITLE="Updatecli failed for calico ${CALICO_VERSION}"
 trap report-error EXIT INT
 
 if [ -n "$CALICO_VERSION" ]; then
-	current_calico_version=$(yq '.version' packages/rke2-calico/templates/crd-template/Chart.yaml)
+	GOCACHE='/home/runner/.cache/go-build' GOPATH='/home/runner/go' PACKAGE='rke2-calico' make prepare
+	GOCACHE='/home/runner/.cache/go-build' GOPATH='/home/runner/go' PACKAGE='rke2-calico-crd' make prepare
+	current_calico_version=$(yq '.version' packages/rke2-calico-crd/charts/Chart.yaml)
 	if [ "$current_calico_version" != "$CALICO_VERSION" ]; then
 		echo "Updating Calico chart to $CALICO_VERSION"
+
 		mkdir workdir
 		wget -P workdir/ https://github.com/projectcalico/calico/releases/download/$CALICO_VERSION/tigera-operator-$CALICO_VERSION.tgz
 		tar --directory=workdir -xf workdir/tigera-operator-$CALICO_VERSION.tgz tigera-operator/values.yaml
 		current_tigera_operator_version=$(yq '.tigeraOperator.version' workdir/tigera-operator/values.yaml)
 		rm -fr workdir
-		sed -i "s/ version: .*/ version: $CALICO_VERSION/g" packages/rke2-calico/generated-changes/patch/Chart.yaml.patch
-		sed -i "s/   version: .*/   version: $current_tigera_operator_version/g" packages/rke2-calico/generated-changes/patch/values.yaml.patch
-		sed -i "s/   tag: .*/   tag: $CALICO_VERSION/g" packages/rke2-calico/generated-changes/patch/values.yaml.patch
-		sed -i "s/ appVersion: .*/ appVersion: $CALICO_VERSION/g" packages/rke2-calico-crd/generated-changes/patch/Chart.yaml.patch
-		sed -i "s/ version: .*/ version: $CALICO_VERSION/g" packages/rke2-calico-crd/generated-changes/patch/Chart.yaml.patch
+
+		yq -i ".version = \"$CALICO_VERSION\"" packages/rke2-calico/charts/Chart.yaml
+		yq -i ".appVersion = \"$CALICO_VERSION\"" packages/rke2-calico/charts/Chart.yaml
+		yq -i ".tigeraOperator.version = \"$current_tigera_operator_version\"" packages/rke2-calico/charts/values.yaml
+		yq -i ".calicoctl.tag = \"$CALICO_VERSION\"" packages/rke2-calico/charts/values.yaml
 		yq -i ".url = \"https://github.com/projectcalico/calico/releases/download/$CALICO_VERSION/tigera-operator-$CALICO_VERSION.tgz\" |
 			.packageVersion = 00" packages/rke2-calico/package.yaml
+
+		yq -i ".version = \"$CALICO_VERSION\"" packages/rke2-calico-crd/charts/Chart.yaml
+		yq -i ".appVersion = \"$CALICO_VERSION\"" packages/rke2-calico-crd/charts/Chart.yaml
 		yq -i ".url = \"https://github.com/projectcalico/calico/releases/download/$CALICO_VERSION/crd.projectcalico.org.v1-$CALICO_VERSION.tgz\" |
 			.packageVersion = 00" packages/rke2-calico-crd/package.yaml
-		GOCACHE='/home/runner/.cache/go-build' GOPATH='/home/runner/go' PACKAGE='rke2-calico' make prepare
-		GOCACHE='/home/runner/.cache/go-build' GOPATH='/home/runner/go' PACKAGE='rke2-calico-crd' make prepare
+
 		find packages/rke2-calico/charts -name '*.orig' -delete
 		find packages/rke2-calico-crd/charts -name '*.orig' -delete
+
 		GOCACHE='/home/runner/.cache/go-build' GOPATH='/home/runner/go' PACKAGE='rke2-calico' make patch
 		GOCACHE='/home/runner/.cache/go-build' GOPATH='/home/runner/go' PACKAGE='rke2-calico-crd' make patch
 		make clean

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -5,4 +5,4 @@ github:
   token: "UPDATECLI_GITHUB_TOKEN"
   repository: "rke2-charts"
   branch: "main-source"
-  owner: "rancher"
+  owner: "mgfritch"


### PR DESCRIPTION


<h3>Chart Images</h3> <ul> <li>rancher/hardened-k8s-metrics-server:v0.8.1-build20260511</li> <li>rancher/hardened-addon-resizer:1.8.23-build20260511</li> </ul>

---



<Actions>
    <action id="bde1d86729bcfef4d3bdc67569113c3a58cc7c3c6c81a5d17bba0c26d2f090c9">
        <h3>Update Kubernetes Metrics Server Chart</h3>
        <details id="c82f360f6d0a5ab3abc522644f63762c78313d2add2f30b305571098e7af9f73">
            <summary>Update chart and images</summary>
            <p>ran shell command &#34;updatecli/scripts/update-metrics-server.sh 3.13.0&#34;</p>
            <details>
                <summary>metrics-server-helm-chart-3.13.0</summary>
                <pre>### Added&#xA;&#xA;- Add chart options to secure the connection between Metrics Server and the Kubernetes API Server. ([#1288](https://github.com/kubernetes-sigs/metrics-server/pull/1288)) _@mkilchhofer_&#xA;- Add `unhealthyPodEvictionPolicy` to the Metrics Server PDB as a user enabled feature. ([#1574](https://github.com/kubernetes-sigs/metrics-server/pull/1574)) @peterabarr&#xA;&#xA;### Changed&#xA;&#xA;- Update the _Addon Resizer_ OCI image to [`1.8.23`](https://github.com/kubernetes/autoscaler/releases/tag/addon-resizer-1.8.23). ([#1626](https://github.com/kubernetes-sigs/metrics-server/pull/1626)) _@stevehipwell_&#xA;- Update the _Metrics Server_ OCI image to [`0.8.0`](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.8.0). ([#1683](https://github.com/kubernetes-sigs/metrics-server/pull/1683)) _@stevehipwell_&#xA;</pre>
            </details>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50" />
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

