### PR TITLE
Update Multus version to v4.2.4-build20260310 and CNI plugins to v1.9.1-build20260511

### DIFF
--- a/packages/rke2-multus/charts/values.yaml
+++ b/packages/rke2-multus/charts/values.yaml
@@ -142,7 +142,7 @@ tolerations:
 cniplugins:
   image:
     repository: rancher/hardened-cni-plugins
-    tag: v1.9.1-build20260506
+    tag: v1.9.1-build20260511
 
   # skipcnis is a comma separated list of cni binaries to skip from
   # installing.

--- a/packages/rke2-multus/package.yaml
+++ b/packages/rke2-multus/package.yaml
@@ -1,3 +1,3 @@
 url: local
 workingDir: charts
-packageVersion: 11
+packageVersion: 12

--- a/updatecli/scripts/create-issue.sh
+++ b/updatecli/scripts/create-issue.sh
@@ -3,7 +3,7 @@
 ISSUE_BODY="Failed workflow run: ${UPDATECLI_GITHUB_WORKFLOW_URL}"
 
 GITHUB_APP="rancher-issues-manager"
-GITHUB_REPOSITORY="rancher/rke2"
+GITHUB_REPOSITORY="mgfritch/rke2"
 
 report-error() {
     exit_code=$?

--- a/updatecli/scripts/update-calico.sh
+++ b/updatecli/scripts/update-calico.sh
@@ -7,27 +7,33 @@ ISSUE_TITLE="Updatecli failed for calico ${CALICO_VERSION}"
 trap report-error EXIT INT
 
 if [ -n "$CALICO_VERSION" ]; then
-	current_calico_version=$(yq '.version' packages/rke2-calico/templates/crd-template/Chart.yaml)
+	GOCACHE='/home/runner/.cache/go-build' GOPATH='/home/runner/go' PACKAGE='rke2-calico' make prepare
+	GOCACHE='/home/runner/.cache/go-build' GOPATH='/home/runner/go' PACKAGE='rke2-calico-crd' make prepare
+	current_calico_version=$(yq '.version' packages/rke2-calico-crd/charts/Chart.yaml)
 	if [ "$current_calico_version" != "$CALICO_VERSION" ]; then
 		echo "Updating Calico chart to $CALICO_VERSION"
+
 		mkdir workdir
 		wget -P workdir/ https://github.com/projectcalico/calico/releases/download/$CALICO_VERSION/tigera-operator-$CALICO_VERSION.tgz
 		tar --directory=workdir -xf workdir/tigera-operator-$CALICO_VERSION.tgz tigera-operator/values.yaml
 		current_tigera_operator_version=$(yq '.tigeraOperator.version' workdir/tigera-operator/values.yaml)
 		rm -fr workdir
-		sed -i "s/ version: .*/ version: $CALICO_VERSION/g" packages/rke2-calico/generated-changes/patch/Chart.yaml.patch
-		sed -i "s/   version: .*/   version: $current_tigera_operator_version/g" packages/rke2-calico/generated-changes/patch/values.yaml.patch
-		sed -i "s/   tag: .*/   tag: $CALICO_VERSION/g" packages/rke2-calico/generated-changes/patch/values.yaml.patch
-		sed -i "s/ appVersion: .*/ appVersion: $CALICO_VERSION/g" packages/rke2-calico-crd/generated-changes/patch/Chart.yaml.patch
-		sed -i "s/ version: .*/ version: $CALICO_VERSION/g" packages/rke2-calico-crd/generated-changes/patch/Chart.yaml.patch
+
+		yq -i ".version = \"$CALICO_VERSION\"" packages/rke2-calico/charts/Chart.yaml
+		yq -i ".appVersion = \"$CALICO_VERSION\"" packages/rke2-calico/charts/Chart.yaml
+		yq -i ".tigeraOperator.version = \"$current_tigera_operator_version\"" packages/rke2-calico/charts/values.yaml
+		yq -i ".calicoctl.tag = \"$CALICO_VERSION\"" packages/rke2-calico/charts/values.yaml
 		yq -i ".url = \"https://github.com/projectcalico/calico/releases/download/$CALICO_VERSION/tigera-operator-$CALICO_VERSION.tgz\" |
 			.packageVersion = 00" packages/rke2-calico/package.yaml
+
+		yq -i ".version = \"$CALICO_VERSION\"" packages/rke2-calico-crd/charts/Chart.yaml
+		yq -i ".appVersion = \"$CALICO_VERSION\"" packages/rke2-calico-crd/charts/Chart.yaml
 		yq -i ".url = \"https://github.com/projectcalico/calico/releases/download/$CALICO_VERSION/crd.projectcalico.org.v1-$CALICO_VERSION.tgz\" |
 			.packageVersion = 00" packages/rke2-calico-crd/package.yaml
-		GOCACHE='/home/runner/.cache/go-build' GOPATH='/home/runner/go' PACKAGE='rke2-calico' make prepare
-		GOCACHE='/home/runner/.cache/go-build' GOPATH='/home/runner/go' PACKAGE='rke2-calico-crd' make prepare
+
 		find packages/rke2-calico/charts -name '*.orig' -delete
 		find packages/rke2-calico-crd/charts -name '*.orig' -delete
+
 		GOCACHE='/home/runner/.cache/go-build' GOPATH='/home/runner/go' PACKAGE='rke2-calico' make patch
 		GOCACHE='/home/runner/.cache/go-build' GOPATH='/home/runner/go' PACKAGE='rke2-calico-crd' make patch
 		make clean

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -5,4 +5,4 @@ github:
   token: "UPDATECLI_GITHUB_TOKEN"
   repository: "rke2-charts"
   branch: "main-source"
-  owner: "rancher"
+  owner: "mgfritch"


### PR DESCRIPTION



<Actions>
    <action id="a95a3c28a0cecabb09b90fa15236c717e7c66bc0755d7396e5ac22f702225a1c">
        <h3>Update Multus version</h3>
        <details id="78a1310e932dd740d125cfa6bf8983b1543245ba701dabe6717a134cf2039d01">
            <summary>Bump to latest multus version in the chart</summary>
            <p>ran shell command &#34;updatecli/scripts/update-multus.sh v4.2.4-build20260310&#34;</p>
            <details>
                <summary>v4.2.4-build20260310</summary>
                <pre>## What&#39;s Changed&#xD;&#xA;* Bump aquasecurity/trivy-action from 0.34.0 to 0.34.1 by @dependabot[bot] in https://github.com/rancher/image-build-multus/pull/126&#xD;&#xA;* Add prime make target to prevent pushing SBOMs to the public repo by @tashima42 in https://github.com/rancher/image-build-multus/pull/127&#xD;&#xA;* Bump aquasecurity/trivy-action from 0.34.2 to 0.35.0 by @dependabot[bot] in https://github.com/rancher/image-build-multus/pull/128&#xD;&#xA;* Bump docker/setup-buildx-action from 3 to 4 by @dependabot[bot] in https://github.com/rancher/image-build-multus/pull/130&#xD;&#xA;* Bump docker/setup-qemu-action from 3 to 4 by @dependabot[bot] in https://github.com/rancher/image-build-multus/pull/131&#xD;&#xA;* Bump docker/build-push-action from 6 to 7 by @dependabot[bot] in https://github.com/rancher/image-build-multus/pull/129&#xD;&#xA;&#xD;&#xA;## New Contributors&#xD;&#xA;* @tashima42 made their first contribution in https://github.com/rancher/image-build-multus/pull/127&#xD;&#xA;&#xD;&#xA;**Full Changelog**: https://github.com/rancher/image-build-multus/compare/v4.2.3-build20260219...v4.2.4-build20260310</pre>
            </details>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50" />
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

